### PR TITLE
eliminate Bound.Name

### DIFF
--- a/src/Eucalypt/Core/Cook.hs
+++ b/src/Eucalypt/Core/Cook.hs
@@ -10,7 +10,6 @@ Stability   : experimental
 -}
 module Eucalypt.Core.Cook where
 
-import Bound.Name
 import Bound.Scope
 import Control.Monad.Loops (untilM_)
 import Control.Monad.State.Lazy
@@ -82,8 +81,8 @@ cookSoup parentAnaphoric es = do
 cookScope ::
      (Anaphora a, Eq b, Show b)
   => Bool
-  -> Scope (Name String b) CoreExp a
-  -> Interpreter (Scope (Name String b) CoreExp a)
+  -> Scope b CoreExp a
+  -> Interpreter (Scope b CoreExp a)
 cookScope anaphoric scope =
   Interpreter $ toScope <$> (cookBottomUp anaphoric . fromScope) scope
 

--- a/src/Eucalypt/Core/EvalByName.hs
+++ b/src/Eucalypt/Core/EvalByName.hs
@@ -92,10 +92,11 @@ handleApply f@CoreBlock {} (x:xs) =
     case b of
       CoreBlock {} -> euMerge whnfM [b, f] >>= (`handleApply` xs)
       _ -> throwEvalError $ BadBlockMerge (CoreExpShow (CoreList [b, f]))
-handleApply f@(CoreLambda n b) as
+handleApply f@(CoreLambda ns b) as
   | length as > n = whnfM (instantiateBody (take n as) b) >>= (`handleApply` drop n as)
   | length as == n = whnfM $ instantiateBody as b
   | length as < n = return (CorePAp n f as)
+  where n = length ns
 handleApply (CoreOperator _ _ expr) as = whnfM expr >>= (`handleApply` as)
 handleApply expr as = throwEvalError $ UncallableExpression (CoreExpShow (CoreApply expr as))
 

--- a/src/Eucalypt/Core/Pretty.hs
+++ b/src/Eucalypt/Core/Pretty.hs
@@ -10,7 +10,6 @@ module Eucalypt.Core.Pretty
   ( pprint
   ) where
 
-import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import Bound.Scope
 import Eucalypt.Core.Syn
@@ -70,18 +69,15 @@ prepare (CoreTraced v) = prepare v
 prepare (CoreChecked _ v) = prepare v
 prepare (CoreOpSoup es) = parens ( hsep $ map prepare es)
 prepare (CoreArgTuple xs) = parens . hsep . punctuate comma $ map prepare xs
-prepare (CoreLambda arity e) =
+prepare (CoreLambda names e) =
   parens $ text "\\" <+> hsep (V.toList (V.map text argNames)) <+> text "->" <+> body
   where
-    pairs = map pair $ bindings e
-    pair b = (b, "?")
-    toBindingName = fromMaybe "?" . (`lookup` pairs)
-    argNames = V.generate arity toBindingName
+    argNames = V.fromList names
     body = prepare $ inst e
     inst =
       splat
         (CoreVar . unquote . show)
-        (CoreVar . show)
+        (CoreVar . (names !!))
 prepare (CoreApply f es) = prepare f <> parens ( hsep . punctuate comma $ map prepare es)
 prepare (CoreName n) = text n
 prepare (CoreOperator x p e) =

--- a/src/Eucalypt/Core/Pretty.hs
+++ b/src/Eucalypt/Core/Pretty.hs
@@ -13,7 +13,6 @@ module Eucalypt.Core.Pretty
 import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import Bound.Scope
-import Bound.Name
 import Eucalypt.Core.Syn
 import Prelude hiding ((<>))
 import Text.PrettyPrint
@@ -58,7 +57,7 @@ prepare (CoreLet bs body) =
   text "let" <+> (vcat binds $$ hang (text "in") 2 prettyBody)
   where
     names = map fst bs
-    inst = splat (CoreVar . unquote . show) (\(Name _ i) -> CoreVar (names !! i))
+    inst = splat (CoreVar . unquote . show) (\i -> CoreVar (names !! i))
     prettyBody = (prepare . inst) body
     bindExprs = map (prepare . inst . snd) bs
     binds = zipWith (\n b -> text n <+> char '=' <+> b) names bindExprs
@@ -75,14 +74,14 @@ prepare (CoreLambda arity e) =
   parens $ text "\\" <+> hsep (V.toList (V.map text argNames)) <+> text "->" <+> body
   where
     pairs = map pair $ bindings e
-    pair (Name n b) = (b, n)
+    pair b = (b, "?")
     toBindingName = fromMaybe "?" . (`lookup` pairs)
     argNames = V.generate arity toBindingName
     body = prepare $ inst e
     inst =
       splat
         (CoreVar . unquote . show)
-        (\(Name nm _) -> CoreVar $ unquote $ show nm)
+        (CoreVar . show)
 prepare (CoreApply f es) = prepare f <> parens ( hsep . punctuate comma $ map prepare es)
 prepare (CoreName n) = text n
 prepare (CoreOperator x p e) =

--- a/test/Eucalypt/Core/DesugarSpec.hs
+++ b/test/Eucalypt/Core/DesugarSpec.hs
@@ -256,12 +256,12 @@ interpolationSpec =
       parseExpression "\"{0}{1}\"" "test" `shouldBe`
       Right
         (Syn.lam
-           ["x", "y"]
+           ["_0", "_1"]
            (Syn.app
               (Syn.bif "JOIN")
               [ Syn.CoreList
-                  [ Syn.app (Syn.bif "STR") [Syn.var "x"]
-                  , Syn.app (Syn.bif "STR") [Syn.var "y"]
+                  [ Syn.app (Syn.bif "STR") [Syn.var "_0"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "_1"]
                   ]
               , Syn.str ""
               ]))
@@ -270,12 +270,12 @@ interpolationSpec =
       parseExpression "\"{}{}\"" "test" `shouldBe`
       Right
         (Syn.lam
-           ["x", "y"]
+           ["_0", "_1"]
            (Syn.app
               (Syn.bif "JOIN")
               [ Syn.CoreList
-                  [ Syn.app (Syn.bif "STR") [Syn.var "x"]
-                  , Syn.app (Syn.bif "STR") [Syn.var "y"]
+                  [ Syn.app (Syn.bif "STR") [Syn.var "_0"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "_1"]
                   ]
               , Syn.str ""
               ]))
@@ -284,12 +284,12 @@ interpolationSpec =
       parseExpression "\"{foo}{}\"" "test" `shouldBe`
       Right
         (Syn.lam
-           ["y"]
+           ["_0"]
            (Syn.app
               (Syn.bif "JOIN")
               [ Syn.CoreList
                   [ Syn.app (Syn.bif "STR") [Syn.var "foo"]
-                  , Syn.app (Syn.bif "STR") [Syn.var "y"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "_0"]
                   ]
               , Syn.str ""
               ]))
@@ -298,13 +298,13 @@ interpolationSpec =
       parseExpression "\"{foo}{1}{}\"" "test" `shouldBe`
       Right
         (Syn.lam
-           ["x", "y"]
+           ["_0", "_1"]
            (Syn.app
               (Syn.bif "JOIN")
               [ Syn.CoreList
                   [ Syn.app (Syn.bif "STR") [Syn.var "foo"]
-                  , Syn.app (Syn.bif "STR") [Syn.var "y"]
-                  , Syn.app (Syn.bif "STR") [Syn.var "x"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "_1"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "_0"]
                   ]
               , Syn.str ""
               ]))

--- a/test/Eucalypt/Core/PrettySpec.hs
+++ b/test/Eucalypt/Core/PrettySpec.hs
@@ -47,7 +47,7 @@ spec =
   describe "PPrint" $ do
     it "prints applications" $
       pprint (app (var "+") [int 2, int 5]) `shouldBe` "+(2, 5)"
-    xit "reconstructs bound names in lambdas" $
+    it "reconstructs bound names in lambdas" $
       pprint (lam ["foo"] (var "foo")) `shouldBe` "(\\ foo -> foo)"
     it "reconstructs bound names in lets" $
       pprint
@@ -58,6 +58,6 @@ spec =
     it "reconstructs bound names even for unused bindings in lets" $
       pprint (letexp [("foo", int 2), ("bar", int 3)] (var "foo")) `shouldBe`
       "let foo = 2\n    bar = 3\n    in foo"
-    xit "prints sample" $
+    it "prints sample" $
       pprint sample `shouldBe`
       "let take = (\\ n l -> (__IF ^InfixLeft(90)^__*CALL* ((n zero?), [], (cons ^InfixLeft(90)^__*CALL* ((l head), (take ^InfixLeft(90)^__*CALL* ((n dec), (l tail))))))))\n    in {[[:take,take]]}"

--- a/test/Eucalypt/Core/PrettySpec.hs
+++ b/test/Eucalypt/Core/PrettySpec.hs
@@ -47,7 +47,7 @@ spec =
   describe "PPrint" $ do
     it "prints applications" $
       pprint (app (var "+") [int 2, int 5]) `shouldBe` "+(2, 5)"
-    it "reconstructs bound names in lambdas" $
+    xit "reconstructs bound names in lambdas" $
       pprint (lam ["foo"] (var "foo")) `shouldBe` "(\\ foo -> foo)"
     it "reconstructs bound names in lets" $
       pprint
@@ -58,6 +58,6 @@ spec =
     it "reconstructs bound names even for unused bindings in lets" $
       pprint (letexp [("foo", int 2), ("bar", int 3)] (var "foo")) `shouldBe`
       "let foo = 2\n    bar = 3\n    in foo"
-    it "prints sample" $
+    xit "prints sample" $
       pprint sample `shouldBe`
       "let take = (\\ n l -> (__IF ^InfixLeft(90)^__*CALL* ((n zero?), [], (cons ^InfixLeft(90)^__*CALL* ((l head), (take ^InfixLeft(90)^__*CALL* ((n dec), (l tail))))))))\n    in {[[:take,take]]}"

--- a/test/Eucalypt/Core/SynSpec.hs
+++ b/test/Eucalypt/Core/SynSpec.hs
@@ -4,7 +4,6 @@ module Eucalypt.Core.SynSpec
   ) where
 
 import Bound
-import Bound.Name
 import Eucalypt.Core.Syn
 import Test.Hspec
 import Data.Maybe (fromJust)
@@ -23,7 +22,7 @@ let2 :: CoreExpr
 let2 = letexp [("a", int 5), ("b", int 2)] body
 
 
-letBody :: CoreExpr -> Maybe (Scope (Name String Int) CoreExp CoreBindingName)
+letBody :: CoreExpr -> Maybe (Scope Int CoreExp CoreBindingName)
 letBody (CoreLet _ b) = Just b
 letBody _ = Nothing
 


### PR DESCRIPTION
Stop using Bound.Name; just gets in the way. Instead keep track of the names explicitly in Lambda and Let

NB. Lambda (&Let) equality now factors in the bound var naming which is awkward but actually used by tests...