### PR TITLE
Performance fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,11 +99,16 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run: mkdir /tmp/artifacts
       - run:
           command: "docker run -t -v /tmp/workspace:/tmp/workspace
+                               -v /tmp/artifacts:/tmp/artifacts
                                -e EXECUTABLE=/tmp/workspace/dist/x86_64-linux/Cabal-2.4.0.1/build/eu/eu
+                               -e GHCRTS=-N2
                                curvelogic/eucalypt-test-harness:latest
-                               pipenv run ./eut.py "
+                               pipenv run ./eut.py -o /tmp/artifacts"
+      - store_artifacts:
+          path: /tmp/artifacts
 
   # Crude benchmarking to spot general trends
   benchmark:
@@ -114,12 +119,17 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run: mkdir /tmp/artifacts
       - run:
           command: "docker run -t -v /tmp/workspace:/tmp/workspace
+                               -v /tmp/artifacts:/tmp/artifacts
                                -e EXECUTABLE=/tmp/workspace/dist/x86_64-linux/Cabal-2.4.0.1/build/eu/eu
+                               -e GHCRTS=-N2
                                curvelogic/eucalypt-test-harness:latest
-                               pipenv run ./eut.py -b -n 25 "
+                               pipenv run ./eut.py -b -n 25 -o /tmp/artifacts"
 
+      - store_artifacts:
+          path: /tmp/artifacts
 
   release:
 
@@ -137,6 +147,46 @@ jobs:
           cd ci
           pipenv run python release.py /tmp/workspace/dist/x86_64-linux/Cabal-2.4.0.1/build/eu/eu
 
+
+  profile:
+    docker:
+      - image: curvelogic/docker-circleci-haskell
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - prof-cache-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+            - prof-cache-{{ checksum "stack.yaml" }}-
+
+      - run: stack setup
+
+      - run: stack install profiterole
+
+      - run:
+          name: Build optimised
+          command: stack build --profile --ghc-options="-O2"
+
+      - run:
+          name: Profile (optimised)
+          command: |
+            stack exec eu -- -e "foldl(+, 0, repeat(1) take(1000))" +RTS -S
+            stack exec eu -- -e "foldl(+, 0, repeat(1) take(1000))" +RTS -p -L250
+            stack exec eu -- -e "foldl(+, 0, repeat(1) take(1000))" +RTS -hc -L250
+            mkdir -p /tmp/artifacts
+            cp eu.prof /tmp/artifacts/eu-${CIRCLE_BUILD_NUM}.prof
+            cp eu.hp /tmp/artifacts/eu-${CIRCLE_BUILD_NUM}.hp
+            stack exec profiterole -- /tmp/artifacts/eu-${CIRCLE_BUILD_NUM}.prof
+
+      - save_cache:
+          paths:
+            - ~/.stack
+          key: prof-cache-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+
+      - store_artifacts:
+          path: /tmp/artifacts
+
+
 workflows:
   version: 2
   build-workflow:
@@ -148,6 +198,10 @@ workflows:
           requires:
             - build
       - benchmark:
+          context: curvelogic-docker-hub
+          requires:
+            - build
+      - profile:
           context: curvelogic-docker-hub
           requires:
             - build

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ library:
     - conduit
     - containers
     - insert-ordered-containers
+    - deepseq
     - deriving-compat
     - directory
     - exceptions

--- a/src/Eucalypt/Driver/Stg.hs
+++ b/src/Eucalypt/Driver/Stg.hs
@@ -15,6 +15,7 @@ module Eucalypt.Driver.Stg
 
 
 import Conduit hiding (throwM)
+import Control.DeepSeq
 import Control.Exception.Safe (handle, IOException, throwM, MonadCatch)
 import Control.Monad (unless)
 import qualified Data.ByteString as BS
@@ -82,6 +83,7 @@ renderConduit opts expr = handle handler $ do
     handler e = throwM $ Execution e
 
 
+
 -- | Step through the machine yielding events via the conduit pipeline
 -- at each stage
 machineSource ::
@@ -100,7 +102,8 @@ machineSource ms = do
         step s `catchC`
         (\(e :: IOException) ->
            throwM $ StgException (IOSystem e) (machineCallStack s))
-      yieldMany $ reverse $ machineEvents s'
+      let events = reverse $ machineEvents s'
+       in events `deepseq` yieldMany events
       unless (machineTerminated s') $ loop s'
 
 

--- a/src/Eucalypt/Driver/Stg.hs
+++ b/src/Eucalypt/Driver/Stg.hs
@@ -100,7 +100,7 @@ machineSource ms = do
         step s `catchC`
         (\(e :: IOException) ->
            throwM $ StgException (IOSystem e) (machineCallStack s))
-      yieldMany $ machineEvents s'
+      yieldMany $ reverse $ machineEvents s'
       unless (machineTerminated s') $ loop s'
 
 

--- a/src/Eucalypt/Stg/CallStack.hs
+++ b/src/Eucalypt/Stg/CallStack.hs
@@ -14,8 +14,6 @@ module Eucalypt.Stg.CallStack where
 
 import Data.Bifunctor (second)
 import Data.Foldable (toList)
-import Data.Vector (Vector)
-import qualified Data.Vector as Vector
 import Eucalypt.Stg.Syn
 import Eucalypt.Core.SourceMap
   ( HasSourceMapIds(..)
@@ -26,27 +24,26 @@ import Eucalypt.Core.SourceMap
 import qualified Eucalypt.Reporting.Location as L
 import qualified Text.PrettyPrint as P
 
--- Structure to track (annotated) call stack
-newtype CallStack = CallStack { entries :: Vector (String, SMID)}
+-- | Structure to track (annotated) call stack
+newtype CallStack = CallStack { entries :: [(String, SMID)]}
   deriving (Eq, Show, Semigroup, Monoid)
 
--- Add a new entry to a call stack
+-- | Add a new entry to a call stack
 addEntry :: (String, SMID) -> CallStack -> CallStack
-addEntry s (CallStack cs) = CallStack (cs `Vector.snoc` s)
+addEntry s (CallStack cs) = CallStack (s : cs)
 
 instance StgPretty CallStack where
   prettify (CallStack cs) =
-    if Vector.null cs
+    if null cs
       then P.empty
       else P.brackets
              (P.hcat (P.punctuate (P.char '>') (map (P.text . fst) (toList cs))))
 
 instance HasSourceMapIds CallStack where
-  toSourceMapIds (CallStack v) = map snd . Vector.toList . Vector.reverse $ v
+  toSourceMapIds (CallStack v) = map snd v
 
 
 -- | Using a SourceMap, resolve SMIDs to allow the call stack to be
 -- reportable in error messages.
 resolveSMIDs :: CallStack -> SourceMap -> [(String, Maybe L.SourceSpan)]
-resolveSMIDs CallStack {..} sm =
-  toList $ Vector.reverse $ Vector.map (second (lookupSource sm)) entries
+resolveSMIDs CallStack {..} sm = map (second (lookupSource sm)) entries

--- a/src/Eucalypt/Stg/CallStack.hs
+++ b/src/Eucalypt/Stg/CallStack.hs
@@ -13,7 +13,6 @@ Stability   : experimental
 module Eucalypt.Stg.CallStack where
 
 import Data.Bifunctor (second)
-import Data.Foldable (toList)
 import Eucalypt.Stg.Syn
 import Eucalypt.Core.SourceMap
   ( HasSourceMapIds(..)
@@ -37,7 +36,8 @@ instance StgPretty CallStack where
     if null cs
       then P.empty
       else P.brackets
-             (P.hcat (P.punctuate (P.char '>') (map (P.text . fst) (toList cs))))
+             (P.hcat (P.punctuate (P.char '>') (map (P.text . fst) (reverse cs))))
+
 
 instance HasSourceMapIds CallStack where
   toSourceMapIds (CallStack v) = map snd v

--- a/src/Eucalypt/Stg/Compiler.hs
+++ b/src/Eucalypt/Stg/Compiler.hs
@@ -19,7 +19,7 @@ import Data.Bifunctor (first, second)
 import Data.Foldable (toList)
 import Data.List (nub, elemIndex, sortOn)
 import Data.Scientific
-import qualified Data.Vector as V
+import qualified Data.Sequence as Seq
 import Eucalypt.Core.Syn as C
 import Eucalypt.Stg.GlobalInfo
 import Eucalypt.Stg.Globals
@@ -308,7 +308,7 @@ wrappers = span isScrutinee . sortOn index . filter notEnvRef
 compileCall :: Int -> [ArgCase a] -> StgSyn
 compileCall envSize components =
   App (Ref $ toRef envSize $ head components) $
-  V.fromList (map (toRef envSize) $ tail components)
+  Seq.fromList (map (toRef envSize) $ tail components)
 
 
 -- | Compile the wrappers

--- a/src/Eucalypt/Stg/Error.hs
+++ b/src/Eucalypt/Stg/Error.hs
@@ -53,6 +53,7 @@ data StgError
   | Panic !String
   | IOSystem IOException
   | InvalidNumber !String
+  | MissingArgument
   deriving (Typeable, Show, Eq)
 
 instance Exception StgException
@@ -123,7 +124,7 @@ instance Reportable StgException where
           (Panic s) -> err s
           (IOSystem e) -> sys $ show e
           (InvalidNumber n) -> err $ "Invalid number (" ++ show n ++ ") could not be parsed."
-
+          MissingArgument -> bug "Expected argument but none found"
 
 
 instance HasSourceMapIds StgException where

--- a/src/Eucalypt/Stg/Eval.hs
+++ b/src/Eucalypt/Stg/Eval.hs
@@ -18,6 +18,7 @@ import Data.Foldable (toList)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
+import qualified Data.Sequence as Seq
 import qualified Data.Vector as Vector
 import Data.Word
 import Eucalypt.Stg.Error
@@ -149,8 +150,9 @@ step ms0@MachineState {machineCode = (Eval (App f xs) env)} = {-# SCC "EvalApp" 
 -- | LET
 step ms0@MachineState {machineCode = (Eval (Let pcs body) env)} = {-# SCC "EvalLet" #-}do
   ms <- prepareStep "EVAL LET" ms0
-  addrs <- liftIO $ traverse (allocClosure env ms) pcs
-  let env' = env <> (ValVec . Vector.map StgAddr) addrs
+  addrs <- liftIO $ traverse (allocClosure env ms) pcs --TODO
+           --allocClosure should create vector
+  let env' = env <> (ValVec . Seq.fromList . map StgAddr . toList) addrs
   return $ setCode ms (Eval body env')
 
 

--- a/src/Eucalypt/Stg/Eval.hs
+++ b/src/Eucalypt/Stg/Eval.hs
@@ -42,22 +42,6 @@ allocPartial le ms lf xs = allocate pap
         }
     a = fromIntegral (_bound lf) - envSize xs
 
--- | Push a continuation onto the stack
-push :: MachineState -> Continuation -> MachineState
-push ms@MachineState {machineStack = st} k =
-  let stackElement = StackElement k (machineCallStack ms)
-   in ms {machineStack = Vector.snoc st stackElement}
-
--- | Pop a continuation off the stack
-pop :: MonadThrow m => MachineState -> m (Maybe Continuation, MachineState)
-pop ms@MachineState {machineStack = st} =
-  if Vector.null st
-    then return (Nothing, ms)
-    else let StackElement k cs = Vector.last st
-          in return
-               ( Just k
-               , ms {machineStack = Vector.init st, machineCallStack = cs})
-
 -- | Push an ApplyToArgs continuation on the stack
 pushApplyToArgs :: MonadThrow m => MachineState -> ValVec -> m MachineState
 pushApplyToArgs ms xs = return $ push ms (ApplyToArgs xs)

--- a/src/Eucalypt/Stg/Eval.hs
+++ b/src/Eucalypt/Stg/Eval.hs
@@ -19,7 +19,6 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq
-import qualified Data.Vector as Vector
 import Data.Word
 import Eucalypt.Stg.Error
 import Eucalypt.Stg.Intrinsics
@@ -102,7 +101,7 @@ step ms0@MachineState {machineCode = (Eval (App f xs) env)} = {-# SCC "EvalApp" 
               (vals env ms xs >>= call le ms lf)
             -- CALLK
             GT ->
-              let (enough, over) = Vector.splitAt (fromIntegral ar) xs
+              let (enough, over) = Seq.splitAt (fromIntegral ar) xs
                in vals env ms over >>= pushApplyToArgs ms >>= \s ->
                     setCallStack cs . setRule "CALLK" . setCode s <$>
                     (vals env ms enough >>= call le ms lf)
@@ -121,7 +120,7 @@ step ms0@MachineState {machineCode = (Eval (App f xs) env)} = {-# SCC "EvalApp" 
                 setCallStack cs . setRule "PCALL EXACT" . setCode ms <$>
                 call le ms code (args <> as)
             GT ->
-              let (enough, over) = Vector.splitAt (fromIntegral ar) xs
+              let (enough, over) = Seq.splitAt (fromIntegral ar) xs
                in vals env ms over >>= pushApplyToArgs ms >>= \s ->
                     vals env ms enough >>= \as ->
                       setCallStack cs . setRule "PCALLK" . setCode s <$>
@@ -263,7 +262,7 @@ step ms0@MachineState {machineCode = (ReturnFun r)} = {-# SCC "ReturnFun" #-} do
        in return $
           setCode
             ms'
-            (Eval (App (Ref $ Vector.head args') (Vector.tail args')) env')
+            (Eval (App (Ref $ args' `Seq.index` 0) (Seq.drop 1 args')) env')
     -- RETFUN into case default... (for forcing lambda-valued exprs)
     (Just (Branch (BranchTable _ _ (Just expr)) le)) ->
       return $ setCode ms' (Eval expr (le <> singleton (StgAddr r)))

--- a/src/Eucalypt/Stg/Event.hs
+++ b/src/Eucalypt/Stg/Event.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-|
 Module      : Eucalypt.Stg.Event
 Description : Spineless tagless G-machine
@@ -10,12 +11,16 @@ Stability   : experimental
 
 module Eucalypt.Stg.Event where
 
+import Control.DeepSeq
 import Eucalypt.Stg.Syn
 import Data.ByteString as BS
+import GHC.Generics (Generic)
 
 newtype RenderMetadata = RenderMetadata
   { metaTag :: Maybe String
-  } deriving (Show, Eq)
+  } deriving (Show, Eq, Generic)
+
+instance NFData RenderMetadata
 
 -- | Various events that can be emitted by the machine, including YAML
 -- / JSON output rendering and debug tracing.
@@ -32,4 +37,6 @@ data Event
   | OutputMappingEnd
   | OutputAlias
   | DebugTrace !BS.ByteString
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance NFData Event

--- a/src/Eucalypt/Stg/Intrinsics/Arithmetic.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Arithmetic.hs
@@ -26,7 +26,7 @@ import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Machine
 import Data.Fixed (mod')
 import Data.Scientific
-import Data.Vector ((!))
+import Data.Sequence ((!?))
 
 binop ::
      (Scientific -> Scientific -> Scientific)
@@ -34,8 +34,8 @@ binop ::
   -> ValVec
   -> IO MachineState
 binop op ms (ValVec args) = do
-  let (StgNat (NativeNumber lhs) _) = args ! 0
-  let (StgNat (NativeNumber rhs) _) = args ! 1
+  let (Just (StgNat (NativeNumber lhs) _)) = args !? 0
+  let (Just (StgNat (NativeNumber rhs) _)) = args !? 1
   return $ setCode ms (ReturnLit (NativeNumber (op lhs rhs)) Nothing)
 
 add :: MachineState -> ValVec -> IO MachineState
@@ -67,8 +67,8 @@ binopBool ::
   -> ValVec
   -> IO MachineState
 binopBool op ms (ValVec args) = do
-  let (StgNat (NativeNumber lhs) _) = args ! 0
-  let (StgNat (NativeNumber rhs) _) = args ! 1
+  let (Just (StgNat (NativeNumber lhs) _)) = args !? 0
+  let (Just (StgNat (NativeNumber rhs) _)) = args !? 1
   return $ setCode ms (ReturnLit (NativeBool (op lhs rhs)) Nothing)
 
 lt :: MachineState -> ValVec -> IO MachineState
@@ -89,7 +89,7 @@ unop ::
   -> ValVec
   -> IO MachineState
 unop op ms (ValVec args) = do
-  let (StgNat (NativeNumber n) _) = args ! 0
+  let (Just (StgNat (NativeNumber n) _)) = args !? 0
   return $ setCode ms (ReturnLit (NativeNumber (op n)) Nothing)
 
 flr :: MachineState -> ValVec -> IO MachineState

--- a/src/Eucalypt/Stg/Intrinsics/Block.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Block.hs
@@ -14,7 +14,7 @@ module Eucalypt.Stg.Intrinsics.Block
   ) where
 
 import Control.Monad (foldM)
-import Data.Vector ((!))
+import Data.Sequence ((!?))
 import Eucalypt.Stg.Error
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Tags
@@ -43,7 +43,7 @@ returnPairList ms om = do
 --
 prune :: MachineState -> ValVec -> IO MachineState
 prune ms (ValVec xs) =
-  let (StgAddr a) = xs ! 0
+  let (Just (StgAddr a)) = xs !? 0
    in pruneSub ms OM.empty a >>= returnPairList ms
 
 
@@ -119,8 +119,8 @@ pruneToMap ms om a = do
 -- The combination thunk is allocated but not evaluated.
 pruneMerge :: MachineState -> ValVec -> IO MachineState
 pruneMerge ms (ValVec xs) =
-  let (StgAddr a) = xs ! 0
-      (StgAddr f) = xs ! 1
+  let (Just (StgAddr a)) = xs !? 0
+      (Just (StgAddr f)) = xs !? 1
    in do om <- pruneMergeSub f OM.empty a
          returnPairList ms om
   where

--- a/src/Eucalypt/Stg/Intrinsics/Common.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Common.hs
@@ -12,7 +12,6 @@ module Eucalypt.Stg.Intrinsics.Common where
 
 import Control.Monad (foldM)
 import qualified Data.Sequence as Seq
-import qualified Data.Vector as V
 import Eucalypt.Stg.Error
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Tags
@@ -82,8 +81,8 @@ readNatList ms addr = do
       case lf of
         LambdaForm {_body = (App (Con t) xs)}
           | t == stgCons -> do
-            (StgNat h _) <- val e ms (V.head xs)
-            (StgAddr a) <- val e ms (xs V.! 1)
+            (StgNat h _) <- val e ms (xs `Seq.index` 0)
+            (StgAddr a) <- val e ms (xs `Seq.index` 1)
             (h :) <$> readNatList ms a
         LambdaForm {_body = (App (Con t) _)}
           | t == stgNil -> return []
@@ -150,8 +149,8 @@ readCons ms addr =
       case lf of
         LambdaForm {_body = (App (Con t) xs)}
           | t == stgCons -> do
-            h' <- val e ms (V.head xs)
-            t' <- val e ms (xs V.! 1)
+            h' <- val e ms (xs `Seq.index` 0)
+            t' <- val e ms (xs `Seq.index` 1)
             return $ Just (h', t')
         LambdaForm {_body = (App (Con t) _)}
           | t == stgNil -> return Nothing
@@ -167,7 +166,7 @@ readBlock ms addr =
     Closure {closureCode = lf, closureEnv = e} ->
       case lf of
         LambdaForm {_body = (App (Con t) xs)}
-          | t == stgBlock -> val e ms (V.head xs)
+          | t == stgBlock -> val e ms (xs `Seq.index` 0)
         LambdaForm {_body = (App (Con _) _)} ->
           throwIn ms $ IntrinsicExpectedBlock (_body lf)
         _ -> throwIn ms $ IntrinsicExpectedEvaluatedBlock (_body lf)

--- a/src/Eucalypt/Stg/Intrinsics/Dict.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Dict.hs
@@ -17,7 +17,9 @@ import Eucalypt.Stg.Error
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Machine
 import qualified Data.Map.Strict as MS
-import Data.Vector ((!))
+import Data.Sequence ((!?))
+
+{-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
 
 intrinsics :: [IntrinsicInfo]
 intrinsics =
@@ -33,16 +35,19 @@ getDictAndKey
   :: MachineState -> ValVec -> IO (MS.Map Native Native, Native)
 getDictAndKey ms args = do
   ns <- getNatives ms args
-  let (NativeDict d) = ns ! 0
-  return (d, ns ! 1)
+  let (Just (NativeDict d)) = ns !? 0
+  let (Just k) = ns !? 1
+  return (d, k)
 
 getDictKeyAndValue
   :: MachineState
      -> ValVec -> IO (MS.Map Native Native, Native, Native)
 getDictKeyAndValue ms args= do
   ns <- getNatives ms args
-  let (NativeDict d) = ns ! 0
-  return (d, ns ! 1, ns ! 2)
+  let (Just (NativeDict d)) = ns !? 0
+  let (Just k) = ns !? 1
+  let (Just v) = ns !? 2
+  return (d, k, v)
 
 -- | __EMPTYDICT
 emptyDict :: MachineState -> ValVec -> IO MachineState
@@ -77,5 +82,5 @@ dictDel ms args = do
 -- | __DICTENTRIES(d)
 dictEntries :: MachineState -> ValVec -> IO MachineState
 dictEntries ms (ValVec args) = do
-  let (StgNat (NativeDict d) _) = args ! 0
+  let (Just (StgNat (NativeDict d) _)) = args !? 0
   returnNatPairList ms (MS.assocs d)

--- a/src/Eucalypt/Stg/Intrinsics/Emit.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Emit.hs
@@ -18,7 +18,7 @@ module Eucalypt.Stg.Intrinsics.Emit
   ) where
 
 import qualified Data.HashMap.Strict.InsOrd as OM
-import Data.Vector ((!))
+import Data.Sequence ((!?))
 import Eucalypt.Stg.Event
 import Eucalypt.Stg.Machine
 import Eucalypt.Stg.Syn
@@ -52,7 +52,7 @@ emitNull s _ = emit s OutputNull
 -- native values.
 emitScalar :: MachineState -> ValVec -> IO MachineState
 emitScalar s (ValVec xs) = do
-  let (StgNat n m) = xs ! 0
+  let (Just (StgNat n m)) = xs !? 0
   event <-
     case m of
       Just meta -> flip OutputScalar n <$> renderMeta s meta

--- a/src/Eucalypt/Stg/Intrinsics/Eq.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Eq.hs
@@ -11,7 +11,7 @@ module Eucalypt.Stg.Intrinsics.Eq where
 
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Machine
-import Data.Vector ((!))
+import Data.Sequence ((!?))
 
 asNative :: StgValue -> Maybe Native
 asNative (StgNat n _) = Just n
@@ -20,6 +20,6 @@ asNative _ = Nothing
 natEq :: MachineState -> ValVec -> IO MachineState
 natEq ms (ValVec xs) =
   (return . setCode ms . (`ReturnLit` Nothing) . NativeBool) $
-  case (asNative $ xs ! 0, asNative $ xs ! 1) of
+  case (xs !? 0 >>= asNative, xs !? 1 >>= asNative) of
     (Just l, Just r) -> l == r
     _ -> False

--- a/src/Eucalypt/Stg/Intrinsics/General.hs
+++ b/src/Eucalypt/Stg/Intrinsics/General.hs
@@ -11,7 +11,7 @@ module Eucalypt.Stg.Intrinsics.General
   ( closed
   ) where
 
-import Data.Vector ((!))
+import Data.Sequence ((!?))
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Machine
 
@@ -22,9 +22,9 @@ import Eucalypt.Stg.Machine
 -- ultimate value of what's at the address is callable or not.
 closed :: MachineState -> ValVec -> IO MachineState
 closed ms (ValVec xs) =
-  case xs ! 0 of
-    (StgNat _ _) -> return $ setCode ms (ReturnLit (NativeBool True) Nothing)
-    (StgAddr a) -> do
+  case xs !? 0 of
+    (Just (StgNat _ _)) -> return $ setCode ms (ReturnLit (NativeBool True) Nothing)
+    (Just (StgAddr a)) -> do
       obj <- peek a
       let ret =
             case obj of
@@ -32,3 +32,4 @@ closed ms (ValVec xs) =
               PartialApplication {papArity = 0} -> True
               _ -> False
       return $ setCode ms (ReturnLit (NativeBool ret) Nothing)
+    Nothing -> error "`closed` called on empty ValVec"

--- a/src/Eucalypt/Stg/Intrinsics/Number.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Number.hs
@@ -17,7 +17,7 @@ import Eucalypt.Stg.Machine
 import Eucalypt.Syntax.Ast (PrimitiveLiteral(..))
 import Eucalypt.Syntax.ParseExpr (number)
 import Data.Scientific
-import Data.Vector ((!))
+import Data.Sequence ((!?))
 import qualified Text.Megaparsec as M
 
 
@@ -29,7 +29,7 @@ toNative _ = Nothing
 -- | Parse text into a number
 parse :: MachineState -> ValVec -> IO MachineState
 parse ms (ValVec args) = do
-  let (StgNat (NativeString text) _) = args ! 0
+  let (Just (StgNat (NativeString text) _)) = args !? 0
   let num = M.parseMaybe number text >>= toNative
   case num of
     (Just n) -> return $ setCode ms (ReturnLit n Nothing)

--- a/src/Eucalypt/Stg/Intrinsics/Panic.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Panic.hs
@@ -12,9 +12,9 @@ module Eucalypt.Stg.Intrinsics.Panic where
 import Eucalypt.Stg.Error
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Machine
-import Data.Vector ((!))
+import Data.Sequence ((!?))
 
 panic :: MachineState -> ValVec -> IO MachineState
 panic ms (ValVec xs) = do
-  let (StgNat (NativeString s) _) = xs ! 0
+  let (Just (StgNat (NativeString s) _)) = xs !? 0
   throwIn ms $ Panic s

--- a/src/Eucalypt/Stg/Intrinsics/Set.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Set.hs
@@ -16,7 +16,7 @@ import Eucalypt.Stg.IntrinsicInfo
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Machine
 import qualified Data.Set as S
-import Data.Vector ((!))
+import Data.Sequence ((!?))
 
 intrinsics :: [IntrinsicInfo]
 intrinsics =
@@ -31,8 +31,9 @@ getSetAndKey
   :: MachineState -> ValVec -> IO (S.Set Native, Native)
 getSetAndKey ms args = do
   ns <- getNatives ms args
-  let (NativeSet d) = ns ! 0
-  return (d, ns ! 1)
+  let (Just (NativeSet d)) = ns !? 0
+  let (Just k) = ns !? 1
+  return (d, k)
 
 
 -- | __EMPTYSET
@@ -60,5 +61,5 @@ setRemove ms args = do
 -- | __SETMEMBERS(s)
 setMembers :: MachineState -> ValVec -> IO MachineState
 setMembers ms (ValVec args) = do
-  let (StgNat (NativeSet s) _) = args ! 0
+  let (Just (StgNat (NativeSet s) _)) = args !? 0
   returnNatList ms (S.toList s)

--- a/src/Eucalypt/Stg/Machine.hs
+++ b/src/Eucalypt/Stg/Machine.hs
@@ -343,8 +343,8 @@ val _ _ (Literal n) = return $ StgNat n Nothing
 
 -- | Resolve a vector of refs against an environment to create
 -- environment
-vals :: MonadThrow m => ValVec -> MachineState -> Vector Ref -> m ValVec
-vals le ms rs = ValVec . Seq.fromList . toList <$> traverse (val le ms) rs
+vals :: MonadThrow m => ValVec -> MachineState -> Seq.Seq Ref -> m ValVec
+vals le ms rs = ValVec <$> traverse (val le ms) rs
 
 -- | Resolve a ref against env and machine to get address of
 -- HeapObject

--- a/src/Eucalypt/Stg/Machine.hs
+++ b/src/Eucalypt/Stg/Machine.hs
@@ -20,9 +20,7 @@ import qualified Data.HashMap.Strict as HM
 import Data.HashMap.Strict (HashMap)
 import Data.IORef
 import Data.Semigroup
-import Data.Vector (Vector)
 import qualified Data.Sequence as Seq
-import qualified Data.Vector as Vector
 import Data.Word
 import Eucalypt.Core.SourceMap
 import Eucalypt.Stg.CallStack
@@ -31,7 +29,8 @@ import Eucalypt.Stg.Event
 import Eucalypt.Stg.Syn
 import Prelude hiding (log)
 import qualified Text.PrettyPrint as P
-import Text.PrettyPrint ((<+>), ($+$))
+import Text.PrettyPrint (($+$), (<+>))
+
 
 -- | A mutable refence to a heap object
 newtype Address =
@@ -239,7 +238,7 @@ data MachineState = MachineState
     -- ^ whether the machine has terminated
   , machineTrace :: MachineState -> IO ()
     -- ^ debug action to run prior to each step
-  , machineEvents :: !(Vector Event)
+  , machineEvents :: ![Event]
     -- ^ events fired by last step
   , machineEmit :: MachineState -> Event -> IO MachineState
     -- ^ emit function to send out events
@@ -387,7 +386,7 @@ appendCallStack ann ms@MachineState {machineCallStack = cs} =
 -- | Append event for this step
 appendEvent :: Event -> MachineState -> MachineState
 appendEvent e ms@MachineState {machineEvents = es0} =
-  ms {machineEvents = es0 `Vector.snoc` e}
+  ms {machineEvents = e : es0}
 
 -- | Build a closure from a STG PreClosure
 buildClosure ::

--- a/src/Eucalypt/Stg/Syn.hs
+++ b/src/Eucalypt/Stg/Syn.hs
@@ -120,7 +120,7 @@ type RefVec = Seq.Seq Ref
 -- 'to'.
 locals :: Word64 -> Word64 -> RefVec
 locals from to =
-  (Local . fromIntegral) <$> Seq.iterateN (fromIntegral (to - from)) (+ 1) from
+  Local . fromIntegral <$> Seq.iterateN (fromIntegral (to - from)) (+ 1) from
 
 localsList :: Int -> Int -> [Ref]
 localsList from to = [Local $ fromIntegral i | i <- [from .. to - 1]]

--- a/src/Eucalypt/Stg/Syn.hs
+++ b/src/Eucalypt/Stg/Syn.hs
@@ -16,6 +16,7 @@ though now not much similarity remains.
 -}
 module Eucalypt.Stg.Syn where
 
+import Control.DeepSeq
 import Data.Foldable (toList)
 import qualified Data.HashMap.Strict as HM
 import Data.Hashable
@@ -46,6 +47,8 @@ data Native
   | NativeSet !(S.Set Native)
   | NativeDict !(MS.Map Native Native)
   deriving (Eq, Show, Generic, Ord)
+
+instance NFData Native
 
 -- | NativeBranchTable matches natives by hash map
 instance Hashable Native where

--- a/src/Eucalypt/Stg/Syn.hs
+++ b/src/Eucalypt/Stg/Syn.hs
@@ -23,8 +23,7 @@ import qualified Data.Map as Map
 import qualified Data.Map.Strict as MS
 import Data.Scientific
 import qualified Data.Set as S
-import Data.Vector (Vector)
-import qualified Data.Vector as V
+import qualified Data.Sequence as Seq
 import Data.Word
 import Eucalypt.Core.SourceMap (SMID)
 import GHC.Generics (Generic)
@@ -115,13 +114,13 @@ envIndex (Local n) = Just n
 envIndex _ = Nothing
 
 -- | Vector of Ref, describing source of free variables
-type RefVec = Vector Ref
+type RefVec = Seq.Seq Ref
 
 -- | Create a ref vec of local environments references from 'from' to
 -- 'to'.
 locals :: Word64 -> Word64 -> RefVec
 locals from to =
-  V.generate (fromIntegral (to - from)) $ Local . (from +) . fromIntegral
+  (Local . fromIntegral) <$> Seq.iterateN (fromIntegral (to - from)) (+ 1) from
 
 localsList :: Int -> Int -> [Ref]
 localsList from to = [Local $ fromIntegral i | i <- [from .. to - 1]]
@@ -268,9 +267,9 @@ data StgSyn
          !BranchTable
   | App !Func
         !RefVec
-  | Let (Vector PreClosure)
+  | Let (Seq.Seq PreClosure)
         !StgSyn
-  | LetRec (Vector PreClosure)
+  | LetRec (Seq.Seq PreClosure)
            !StgSyn
   | Ann !String !SMID !StgSyn
   deriving (Eq, Show)
@@ -328,19 +327,19 @@ polycase_ scrutinee bs nbs df =
   Case scrutinee (BranchTable (Map.fromList bs) (HM.fromList nbs) df)
 
 let_ :: [PreClosure] -> StgSyn -> StgSyn
-let_ pcs = Let (V.fromList pcs)
+let_ pcs = Let (Seq.fromList pcs)
 
 letrec_ :: [PreClosure] -> StgSyn -> StgSyn
-letrec_ pcs = LetRec (V.fromList pcs)
+letrec_ pcs = LetRec (Seq.fromList pcs)
 
 appfn_ :: Ref -> [Ref] -> StgSyn
-appfn_ f xs = App (Ref f) $ V.fromList xs
+appfn_ f xs = App (Ref f) $ Seq.fromList xs
 
 appbif_ :: Int -> [Ref] -> StgSyn
-appbif_ f xs = App (Intrinsic f) $ V.fromList xs
+appbif_ f xs = App (Intrinsic f) $ Seq.fromList xs
 
 appcon_ :: Tag -> [Ref] -> StgSyn
-appcon_ t xs = App (Con t) $ V.fromList xs
+appcon_ t xs = App (Con t) $ Seq.fromList xs
 
 lam_ :: Int -> Int -> StgSyn -> LambdaForm
 lam_ f b = LambdaForm (fromIntegral f) (fromIntegral b) False
@@ -373,10 +372,10 @@ pc0m_ :: Ref -> LambdaForm -> PreClosure
 pc0m_ meta = PreClosure mempty (Just meta)
 
 pc_ :: [Ref] -> LambdaForm -> PreClosure
-pc_ = (`PreClosure` Nothing) . V.fromList
+pc_ = (`PreClosure` Nothing) . Seq.fromList
 
 pcm_ :: [Ref] -> Maybe Ref -> LambdaForm -> PreClosure
-pcm_ rs = PreClosure (V.fromList rs)
+pcm_ rs = PreClosure (Seq.fromList rs)
 
 ann_ :: String -> SMID -> StgSyn -> StgSyn
 ann_ = Ann
@@ -386,4 +385,4 @@ ann_ = Ann
 standardConstructor :: Word64 -> Tag -> LambdaForm
 standardConstructor f t =
   LambdaForm f 0 False $
-  App (Con t) $ V.generate (fromIntegral f) $ Local . fromIntegral
+  App (Con t) $ Local <$> Seq.iterateN (fromIntegral f) (+ 1) 0

--- a/test/Eucalypt/Stg/EvalSpec.hs
+++ b/test/Eucalypt/Stg/EvalSpec.hs
@@ -9,7 +9,7 @@ Stability   : experimental
 module Eucalypt.Stg.EvalSpec (main, spec)
 where
 
-import qualified Data.Vector as Vector
+import qualified Data.Sequence as Seq
 import Eucalypt.Stg.Compiler
 import Eucalypt.Stg.Event
 import Eucalypt.Stg.Intrinsics
@@ -33,7 +33,7 @@ headOfList =
     [ pc0_ $ thunk_ $ appfn_ (Global "HEAD") []
     , pc0_ $ thunk_ (litList_ 0 [nat 1, nat 2])
     ]
-    (App (Ref (Local 0)) $ Vector.singleton (Local 1))
+    (App (Ref (Local 0)) $ Seq.singleton (Local 1))
 
 -- A test which adds 1 and 2...
 addTest :: StgSyn

--- a/test/Eucalypt/Stg/Intrinsics/CommonSpec.hs
+++ b/test/Eucalypt/Stg/Intrinsics/CommonSpec.hs
@@ -12,7 +12,7 @@ module Eucalypt.Stg.Intrinsics.CommonSpec
   , spec
   ) where
 
-import qualified Data.Vector as V
+import Data.Sequence ((!?))
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Tags
 import Eucalypt.Stg.Machine
@@ -39,8 +39,8 @@ readsReturns ns =
     case ms' of
       MachineState {machineCode = (ReturnCon c (ValVec xs) _)}
         | c == stgCons -> do
-          let (StgNat h _) = V.head xs
-          let (StgAddr t) = xs V.! 1
+          let (Just (StgNat h _)) = xs !? 0
+          let (Just (StgAddr t)) = xs !? 1
           r <- run $ (h :) <$> readNatList ms' t
           assert $ r == ns
         | c == stgNil -> assert $ null ns

--- a/test/Eucalypt/Stg/SynSpec.hs
+++ b/test/Eucalypt/Stg/SynSpec.hs
@@ -9,7 +9,7 @@ Stability   : experimental
 module Eucalypt.Stg.SynSpec (main, spec)
 where
 
-import Data.Vector (fromList)
+import Data.Sequence (fromList)
 import Eucalypt.Stg.Syn
 import Test.Hspec
 


### PR DESCRIPTION
Mainly reduce memory usage by switching vectors for sequences and lists. Vectors were a hangover of some code originally lifted from something that was using mutable vectors in primitive monad. That's all gone. Apart from some ugly Word64 stuff that needs cleaning up.