### PR TITLE
Restrict __CAT to core

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -411,7 +411,7 @@ compose(f, g, x): x g f
 (l @ r): l(r)
 
 ` "`apply(f, xs)` - apply function `f` to arguments in list `xs`."
-apply(f, xs): foldl(cat flip, f, xs)
+apply(f, xs): foldl(_0(_1), f, xs)
 
 ` "`flip(f)` - flip arguments of function `f`, flip(f)(x, y) == f(y, x)"
 flip(f, x, y): f(y, x)
@@ -737,7 +737,7 @@ tongue(ks, v): foldr({k: • e: •}.([[k, e]] block), v, ks)
 
 ` "merge-at(ks, v, b) - shallow merge block `v` into block value at path-of-keys `ks`"
 merge-at(ks, v, b): if(ks nil?,
-                       b v,
+                       merge(b, v),
 		       b update-value-or(ks head,
 		                         merge-at(ks tail, v),
 					 tongue(ks tail, v)))

--- a/src/Eucalypt/Core/Decatenater.hs
+++ b/src/Eucalypt/Core/Decatenater.hs
@@ -1,0 +1,23 @@
+{-|
+Module      : Eucalypt.Core.Decatenater
+Description : Pass for replacing catenations with applications
+Copyright   : (c) Greg Hawkins, 2018
+License     :
+Maintainer  : greg@curvelogic.co.uk
+Stability   : experimental
+-}
+module Eucalypt.Core.Decatenater where
+
+import Eucalypt.Core.Recursion
+import Eucalypt.Core.Syn
+
+
+-- | Replace __CAT with applications.
+--
+-- Later catenation may be overridable but for now this is
+-- straightfoward and we can eliminate it entirely in core phase
+-- before getting to the STG execution
+decatenate :: CoreExp a -> CoreExp a
+decatenate (CoreApply smid (CoreBuiltin _ "CAT") [x, f]) =
+  CoreApply smid (decatenate f) [decatenate x]
+decatenate e = walk decatenate e

--- a/src/Eucalypt/Core/Inliner.hs
+++ b/src/Eucalypt/Core/Inliner.hs
@@ -14,8 +14,11 @@ import Eucalypt.Core.Recursion
 import Eucalypt.Core.Syn
 
 
+-- | Tag lambdas that can be distributed out to call sites, distribute
+-- them and then beta reduce at the call site.
 inline :: CoreExp a -> CoreExp a
 inline = betaReduce . distribute . tagInlinables
+
 
 
 -- | Distribute the definition down the tree to all call sites.

--- a/src/Eucalypt/Core/Simplify.hs
+++ b/src/Eucalypt/Core/Simplify.hs
@@ -25,4 +25,4 @@ simplify =
   let eliminateDeadCode = prune . prune . prune . prune
       runInlines = prune . prune . inline . inline . inline
    in eliminateDeadCode >>>
-      decatenate >>> runInlines >>> compress >>> cleanEvaluand
+      runInlines >>> compress >>> decatenate >>> cleanEvaluand

--- a/src/Eucalypt/Core/Simplify.hs
+++ b/src/Eucalypt/Core/Simplify.hs
@@ -1,0 +1,28 @@
+{-|
+Module      : Eucalypt.Core.Simplify
+Description : Passes for simplifying core code (including inlining
+              decatenation, etc.)
+Copyright   : (c) Greg Hawkins, 2018
+License     :
+Maintainer  : greg@curvelogic.co.uk
+Stability   : experimental
+-}
+module Eucalypt.Core.Simplify
+  ( simplify
+  ) where
+
+import Control.Arrow ((>>>))
+import Eucalypt.Core.Decatenater (decatenate)
+import Eucalypt.Core.Inliner (inline)
+import Eucalypt.Core.Eliminate (prune, compress)
+import Eucalypt.Core.Verify (cleanEvaluand)
+import Eucalypt.Core.Syn
+
+-- | A suite of simplifying core passes, to be run after "cooking" but
+-- prior to compilation to STG
+simplify :: Show a => CoreExp a -> CoreExp a
+simplify =
+  let eliminateDeadCode = prune . prune . prune . prune
+      runInlines = prune . prune . inline . inline . inline
+   in eliminateDeadCode >>>
+      decatenate >>> runInlines >>> compress >>> cleanEvaluand

--- a/src/Eucalypt/Driver/Options.hs
+++ b/src/Eucalypt/Driver/Options.hs
@@ -33,7 +33,6 @@ data Command
   | DumpDesugared
   | DumpEvalSubstituted
   | DumpCooked
-  | DumpPrunedCore
   | DumpFinalCore
   | DumpStg
   deriving (Show, Eq)
@@ -100,10 +99,6 @@ commandOption =
     DumpCooked
     (long "dump-cooked" <>
      help "Dump core syntax after operator fixities have been resolved") <|>
-  flag'
-    DumpPrunedCore
-    (long "dump-pruned-core" <>
-     help "Dump core syntax after first prune of dead code") <|>
   flag'
     DumpFinalCore
     (long "dump-core" <>

--- a/src/Eucalypt/Stg/Address.hs
+++ b/src/Eucalypt/Stg/Address.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleContexts, LambdaCase #-}
+
+{-|
+Module      : Eucalypt.Stg.Address
+Description : Addresses and abstract memory operations for the STG machine
+Copyright   : (c) Greg Hawkins, 2018
+License     :
+Maintainer  : greg@curvelogic.co.uk
+Stability   : experimental
+
+-}
+
+module Eucalypt.Stg.Address where
+
+import Control.Monad.IO.Class
+import Data.IORef
+
+
+-- | A mutable refence to a heap object
+newtype AbstractAddress a =
+  Address (IORef a)
+  deriving (Eq)
+
+instance Show (AbstractAddress a) where
+  show _ = "0x?"
+
+-- | Allocate a new heap object, return address
+allocate :: MonadIO m => a -> m (AbstractAddress a)
+allocate obj = liftIO $ Address <$> newIORef obj
+
+-- | Replace the heap object at this address
+poke :: MonadIO m => AbstractAddress a -> a -> m ()
+poke (Address r) = liftIO . writeIORef r
+
+-- | Retrieve the heap object at this address
+peek :: MonadIO m => AbstractAddress a -> m a
+peek (Address r) = liftIO $ readIORef r

--- a/src/Eucalypt/Stg/Address.hs
+++ b/src/Eucalypt/Stg/Address.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE FlexibleContexts, LambdaCase #-}
-
 {-|
 Module      : Eucalypt.Stg.Address
 Description : Addresses and abstract memory operations for the STG machine

--- a/src/Eucalypt/Stg/Error.hs
+++ b/src/Eucalypt/Stg/Error.hs
@@ -56,6 +56,7 @@ data StgError
   | IOSystem IOException
   | InvalidNumber !String
   | MissingArgument
+  | AppliedDataStructureToMoreThanOneArgument
   deriving (Typeable, Show, Eq)
 
 instance Exception StgException
@@ -134,6 +135,8 @@ instance Reportable StgException where
           (InvalidNumber n) ->
             err $ "Invalid number (" ++ show n ++ ") could not be parsed."
           MissingArgument -> bug "Expected argument but none found"
+          AppliedDataStructureToMoreThanOneArgument ->
+            bug "A data structure was applied to more than one argument"
 
 
 instance HasSourceMapIds StgException where

--- a/src/Eucalypt/Stg/Eval.hs
+++ b/src/Eucalypt/Stg/Eval.hs
@@ -132,10 +132,9 @@ applyOver ms ref _arity _cs env _le LambdaForm {_body = (App (Con _) _)} xs =
     code =
       Eval (App (Ref $ Global "MERGE") (Seq.fromList [Seq.index xs 0, ref])) env
 applyOver ms _ref arity cs env le lf xs = do
-  (ValVec values) <- vals env ms xs
-  let (enough, over) = Seq.splitAt (fromIntegral arity) values
-  ms' <- pushApplyToArgs ms (ValVec over)
-  code <- call le ms' lf (ValVec enough)
+  (enough, over) <- splitVecAt arity <$> vals env ms xs
+  ms' <- pushApplyToArgs ms over
+  code <- call le ms' lf enough
   return $
     ms'
       {machineCode = code, machineCallStack = cs} //? "CALLK"
@@ -196,10 +195,9 @@ applyPartialOver ::
   -> RefVec
   -> m MachineState
 applyPartialOver ms arity cs env args le lf xs = do
-  (ValVec values) <- vals env ms xs
-  let (enough, over) = Seq.splitAt (fromIntegral arity) values
-  ms' <- pushApplyToArgs ms (ValVec over)
-  code <- call le ms' lf (args <> ValVec enough)
+  (enough, over) <- splitVecAt arity <$> vals env ms xs
+  ms' <- pushApplyToArgs ms over
+  code <- call le ms' lf (args <> enough)
   return $
     ms'
       { machineCode = code

--- a/src/Eucalypt/Stg/Eval.hs
+++ b/src/Eucalypt/Stg/Eval.hs
@@ -22,6 +22,7 @@ import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq
 import Data.Word
+import Eucalypt.Stg.Address (allocate, peek, poke)
 import Eucalypt.Stg.CallStack
 import Eucalypt.Stg.Error
 import Eucalypt.Stg.Intrinsics

--- a/src/Eucalypt/Stg/Globals.hs
+++ b/src/Eucalypt/Stg/Globals.hs
@@ -37,15 +37,13 @@ euStgNil = value_ $ appcon_ stgNil mempty
 euEmptyBlock :: LambdaForm
 euEmptyBlock = thunk_ $ appcon_ stgBlock [Global "KNIL"]
 
--- | __CAT(x, f)
+-- | __CAT is a "fake" builtin that should be eliminated during core
+-- phase and so this should never be called
 euCat :: LambdaForm
 euCat =
   lam_ 0 2 $
   ann_ "__CAT" 0 $
-  casedef_
-    (Atom (Local 1))
-    [(stgBlock, (1, appfn_ (Global "MERGE") [Local 0, Local 1]))] $
-  appfn_ (Local 1) [Local 0]
+  appfn_ (Global "PANIC") [Literal $ NativeString "Uneliminated call to __CAT"]
 
 
 -- | Strictly evaluate a list of natives to NF

--- a/src/Eucalypt/Stg/Intrinsics/Block.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Block.hs
@@ -15,6 +15,7 @@ module Eucalypt.Stg.Intrinsics.Block
 
 import Control.Monad (foldM)
 import Data.Sequence ((!?))
+import Eucalypt.Stg.Address (allocate)
 import Eucalypt.Stg.Error
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Tags

--- a/src/Eucalypt/Stg/Intrinsics/Common.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Common.hs
@@ -18,6 +18,7 @@ import Data.List (intercalate)
 import qualified Data.Sequence as Seq
 import Data.Scientific (Scientific, floatingOrInteger)
 import Data.Sequence (Seq)
+import Eucalypt.Stg.Address (allocate, peek)
 import Eucalypt.Stg.Error
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Tags

--- a/src/Eucalypt/Stg/Intrinsics/Emit.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Emit.hs
@@ -19,6 +19,7 @@ module Eucalypt.Stg.Intrinsics.Emit
 
 import qualified Data.HashMap.Strict.InsOrd as OM
 import Data.Sequence ((!?))
+import Eucalypt.Stg.Address (peek)
 import Eucalypt.Stg.Event
 import Eucalypt.Stg.Machine
 import Eucalypt.Stg.Syn

--- a/src/Eucalypt/Stg/Intrinsics/General.hs
+++ b/src/Eucalypt/Stg/Intrinsics/General.hs
@@ -13,6 +13,7 @@ module Eucalypt.Stg.Intrinsics.General
 
 import Data.Sequence ((!?))
 import Eucalypt.Stg.Syn
+import Eucalypt.Stg.Address (peek)
 import Eucalypt.Stg.Machine
 
 -- | Is the heap object at the specified address a closed term?

--- a/src/Eucalypt/Stg/Intrinsics/Meta.hs
+++ b/src/Eucalypt/Stg/Intrinsics/Meta.hs
@@ -13,6 +13,7 @@ module Eucalypt.Stg.Intrinsics.Meta
   ) where
 
 import Data.Sequence ((!?))
+import Eucalypt.Stg.Address (peek, allocate)
 import Eucalypt.Stg.Error
 import Eucalypt.Stg.Machine
 import Eucalypt.Stg.Syn

--- a/src/Eucalypt/Stg/Machine.hs
+++ b/src/Eucalypt/Stg/Machine.hs
@@ -143,6 +143,12 @@ extendEnv env args = (env', rs)
     env' = env <> args
     rs = locals envlen (arglen + envlen)
 
+-- | Split a ValVec in two at the specified index
+splitVecAt :: Integral a => a -> ValVec -> (ValVec, ValVec)
+splitVecAt n (ValVec vs) =
+  let (l, r) = Seq.splitAt (fromIntegral n) vs
+   in (ValVec l, ValVec r)
+
 instance Semigroup ValVec where
   (<>) (ValVec l) (ValVec r) = ValVec $ l Seq.>< r
 

--- a/src/Eucalypt/Stg/Machine.hs
+++ b/src/Eucalypt/Stg/Machine.hs
@@ -373,6 +373,10 @@ setCode ms@MachineState {} c = ms {machineCode = c}
 setRule :: String -> MachineState -> MachineState
 setRule r ms@MachineState {} = ms {machineLastStepName = r}
 
+infixl 5 //?
+(//?) :: MachineState -> String -> MachineState
+(//?) ms@MachineState {} r =  ms {machineLastStepName = r}
+
 -- | Set the current call stack
 setCallStack :: CallStack -> MachineState -> MachineState
 setCallStack cs ms = ms { machineCallStack = cs }

--- a/test/Eucalypt/Stg/MachineSpec.hs
+++ b/test/Eucalypt/Stg/MachineSpec.hs
@@ -9,6 +9,7 @@ Stability   : experimental
 module Eucalypt.Stg.MachineSpec (main, spec)
 where
 
+import Eucalypt.Stg.Address
 import Eucalypt.Stg.Syn
 import Eucalypt.Stg.Machine
 import Eucalypt.Stg.StandardMachine

--- a/test/Eucalypt/Stg/StgTestUtil.hs
+++ b/test/Eucalypt/Stg/StgTestUtil.hs
@@ -10,6 +10,7 @@ Stability   : experimental
 module Eucalypt.Stg.StgTestUtil where
 
 import Data.Foldable (toList, traverse_)
+import Eucalypt.Stg.Address
 import Eucalypt.Stg.Compiler
 import Eucalypt.Stg.Eval (run)
 import Eucalypt.Stg.Event


### PR DESCRIPTION
Notion of catenation should be implemented entirely as core transformation. Removing from STG-world.